### PR TITLE
Show latest created_at timestamp for mirror in cli

### DIFF
--- a/aionostr/cli.py
+++ b/aionostr/cli.py
@@ -3,6 +3,7 @@ import sys
 import click
 import asyncio
 import time
+import datetime
 import os
 import logging
 from functools import wraps
@@ -173,7 +174,7 @@ async def mirror(anything, relays, target, verbose, since):
                 click.echo(f'{event.id} from {event.pubkey}')
             else:
                 if count % 100 == 0:
-                    click.echo(f'{count}...')
+                    click.echo(f'{count}...{str(datetime.datetime.utcfromtimestamp(event.created_at))}')
         click.echo(f'{count} sent')
 
 


### PR DESCRIPTION
Hi thanks for your great work.
This small improvement shows the current created_at timestamp of the last event when doing mirror:

```
284000...2022-12-21 16:04:32
284100...2022-12-21 16:04:34
284200...2022-12-21 16:04:36
```

This helps to understand whats currently happening